### PR TITLE
By default take most recent rate. 

### DIFF
--- a/core/app/models/spree/stock/estimator.rb
+++ b/core/app/models/spree/stock/estimator.rb
@@ -18,7 +18,7 @@ module Spree
       private
       def choose_default_shipping_rate(shipping_rates)
         unless shipping_rates.empty?
-          shipping_rates.min_by(&:cost).selected = true
+          shipping_rates.max_by(&:shipping_method_id).selected = true
         end
       end
 


### PR DESCRIPTION
This will allow us to set a previously deprecated rate to be set as 'frontend' and not have it used by default.  This is necessary to maintain old rates through an order.update!

@quetzaluz 
