### PR TITLE
- Sets use_transactions to true for state_machine models.

### DIFF
--- a/core/app/models/spree/order/checkout.rb
+++ b/core/app/models/spree/order/checkout.rb
@@ -38,7 +38,7 @@ module Spree
             # To avoid multiple occurrences of the same transition being defined
             # On first definition, state_machines will not be defined
             state_machines.clear if respond_to?(:state_machines)
-            state_machine :state, initial: :cart, use_transactions: false, action: :save_state do
+            state_machine :state, initial: :cart, use_transactions: true, action: :save_state do
               klass.next_event_transitions.each { |t| transition(t.merge(on: :next)) }
 
               # Persist the state on the order

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -30,7 +30,7 @@ module Spree
     scope :trackable, -> { where("tracking IS NOT NULL AND tracking != ''") }
 
     # shipment state machine (see http://github.com/pluginaweek/state_machine/tree/master for details)
-    state_machine initial: :pending, use_transactions: false do
+    state_machine initial: :pending, use_transactions: true do
       event :ready do
         transition from: :pending, to: :ready, if: lambda { |shipment|
           # Fix for #2040


### PR DESCRIPTION
@kknd113 

This is deployed to 172.16.202.134 if you want to evaluate it. I'll leave that deployment up for a little while but might shut it down later this weekend.

I spammed requests in multiple tabs for one order (hit the place order button 20 times, updated every item in the cart at once) and didn't see a single deadlock error with this in place.
