### PR TITLE
Backend: when refreshing shipping rates, include backend only shippin…

### DIFF
--- a/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
+++ b/backend/app/controllers/spree/admin/orders/customer_details_controller.rb
@@ -24,8 +24,7 @@ module Spree
               @order.associate_user!(Spree.user_class.find(params[:user_id]), @order.email.blank?)
             end
             while @order.next; end
-
-            @order.refresh_shipment_rates
+            @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
             flash[:success] = Spree.t('customer_details_updated')
             redirect_to admin_order_customer_path(@order)
           else

--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -54,7 +54,7 @@ module Spree
 
       def edit
         unless @order.completed?
-          @order.refresh_shipment_rates
+          @order.refresh_shipment_rates(ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
         end
       end
 

--- a/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/orders/customer_details_controller_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "cancan"
+require "spree/testing_support/bar_ability"
+
+describe Spree::Admin::Orders::CustomerDetailsController, type: :controller do
+
+  context "with authorization" do
+    stub_authorization!
+
+    let(:order) do
+      mock_model(
+        Spree::Order,
+        total:           100,
+        number:          "R123456789",
+        billing_address: mock_model(Spree::Address)
+      )
+    end
+
+    before do
+      allow(Spree::Order).to receive_messages(find_by_number!: order)
+    end
+
+    context "#update" do
+      it "does refresh the shipment rates with all shipping methods" do
+        allow(order).to receive_messages(update_attributes: true)
+        allow(order).to receive_messages(next: false)
+        expect(order).to receive(:refresh_shipment_rates)
+          .with(Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END)
+        attributes = {
+          order_id: order.number,
+          order: {
+            email: "",
+            use_billing: "",
+            bill_address_attributes: {},
+            ship_address_attributes: {}
+          }
+        }
+        spree_put :update, attributes
+      end
+    end
+  end
+end

--- a/backend/spec/features/admin/orders/order_details_spec.rb
+++ b/backend/spec/features/admin/orders/order_details_spec.rb
@@ -99,6 +99,23 @@ describe "Order Details", type: :feature, js: true do
         expect(page).to have_content("Default")
       end
 
+      it "can assign a back-end only shipping method" do
+        create(:shipping_method, name: "Backdoor", display_on: "back_end")
+        order = create(
+          :completed_order_with_totals,
+          shipping_method_filter: Spree::ShippingMethod::DISPLAY_ON_FRONT_AND_BACK_END
+        )
+        visit spree.edit_admin_order_path(order)
+        within("table.index tr.show-method") do
+          click_icon :edit
+        end
+        select2 "Backdoor", from: "Shipping Method"
+        click_icon :ok
+
+        expect(page).not_to have_css('#selected_shipping_rate_id')
+        expect(page).to have_content("Backdoor")
+      end
+
       it "will show the variant sku" do
         order = create(:completed_order_with_totals)
         visit spree.edit_admin_order_path(order)
@@ -200,7 +217,7 @@ describe "Order Details", type: :feature, js: true do
           end
         end
       end
-      
+
       context "with special_instructions present" do
         let(:order) { create(:order, :state => 'complete', :completed_at => "2011-02-01 12:36:15", :number => "R100", :special_instructions => "Very special instructions here") }
         it "will show the special_instructions" do
@@ -233,7 +250,7 @@ describe "Order Details", type: :feature, js: true do
   end
 
   context 'with only read permissions' do
-    before do 
+    before do
       allow_any_instance_of(Spree::Admin::BaseController).to receive(:spree_current_user).and_return(nil)
     end
 

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -535,8 +535,8 @@ module Spree
       )
     end
 
-    def refresh_shipment_rates
-      shipments.map &:refresh_rates
+    def refresh_shipment_rates(shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
+      shipments.map { |s| s.refresh_rates(shipping_method_filter) }
     end
 
     def shipping_eq_billing_address?

--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -115,14 +115,15 @@ module Spree
       selected_shipping_rate.try(:tax_rate).try(:tax_category)
     end
 
-    def refresh_rates
+    def refresh_rates(shipping_method_filter = ShippingMethod::DISPLAY_ON_FRONT_END)
       return shipping_rates if shipped?
       return [] unless can_get_rates?
 
       # StockEstimator.new assigment below will replace the current shipping_method
       original_shipping_method_id = shipping_method.try(:id)
 
-      self.shipping_rates = Stock::Estimator.new(order).shipping_rates(to_package)
+      self.shipping_rates = Stock::Estimator.new(order)
+      .shipping_rates(to_package, shipping_method_filter)
 
       if shipping_method
         selected_rate = shipping_rates.detect { |rate|

--- a/core/app/models/spree/shipping_method.rb
+++ b/core/app/models/spree/shipping_method.rb
@@ -4,7 +4,12 @@ module Spree
     include Spree::Core::CalculatedAdjustments
     DISPLAY = [:both, :front_end, :back_end]
 
-    default_scope -> { where(deleted_at: nil) }
+    # Used for #refresh_rates
+    DISPLAY_ON_FRONT_AND_BACK_END = 0
+    DISPLAY_ON_FRONT_END = 1
+    DISPLAY_ON_BACK_END = 2
+
+    default_scope { where(deleted_at: nil) }
 
     has_many :shipping_method_categories, :dependent => :destroy
     has_many :shipping_categories, through: :shipping_method_categories
@@ -44,6 +49,12 @@ module Spree
 
     def tax_category
       Spree::TaxCategory.unscoped { super }
+    end
+
+    def available_to_display(display_filter)
+      display_filter == DISPLAY_ON_FRONT_AND_BACK_END ||
+      (frontend? && display_filter == DISPLAY_ON_FRONT_END) ||
+      (!frontend? && display_filter == DISPLAY_ON_BACK_END)
     end
 
     private

--- a/core/lib/spree/testing_support/factories/order_factory.rb
+++ b/core/lib/spree/testing_support/factories/order_factory.rb
@@ -18,6 +18,8 @@ FactoryGirl.define do
 
       transient do
         line_items_count 5
+        shipment_cost 100
+        shipping_method_filter Spree::ShippingMethod::DISPLAY_ON_FRONT_END
       end
 
       after(:create) do |order, evaluator|
@@ -33,8 +35,8 @@ FactoryGirl.define do
       factory :completed_order_with_totals do
         state 'complete'
 
-        after(:create) do |order|
-          order.refresh_shipment_rates
+        after(:create) do |order, evaluator|
+          order.refresh_shipment_rates(evaluator.shipping_method_filter)
           order.update_column(:completed_at, Time.now)
         end
 

--- a/core/spec/models/spree/stock/estimator_spec.rb
+++ b/core/spec/models/spree/stock/estimator_spec.rb
@@ -117,7 +117,7 @@ module Spree
           before do
             allow(backend_method).to receive_message_chain(:calculator, :compute).and_return(0.00)
             allow(generic_method).to receive_message_chain(:calculator, :compute).and_return(5.00)
-            allow(subject).to receive(:shipping_methods).and_return([backend_method, generic_method])
+            allow(package).to receive(:shipping_methods).and_return([backend_method, generic_method])
           end
 
           it "does not return backend rates at all" do


### PR DESCRIPTION
…g methods

Add specs for the back_end only shipping methods changes

fixes #5758
fixes #5755

@schwartzdev Backported the fix. Would like to run test against this and push this live before putting https://github.com/dotandbo/dotandbo-spree/pull/4608 live.
