### PR TITLE
disable/remove regenerate api key button

### DIFF
--- a/backend/app/views/spree/admin/users/edit.html.erb
+++ b/backend/app/views/spree/admin/users/edit.html.erb
@@ -33,13 +33,7 @@
     <div class="filter-actions actions">
       <%= form_tag spree.clear_api_key_admin_user_path(@user), :method => :put do %>
         <%= button Spree.t('clear_key', :scope => 'api'), 'trash' %>
-      <% end %>
-
-      <span class="or"><%= Spree.t(:or)%></span>
-
-      <%= form_tag spree.generate_api_key_admin_user_path(@user), :method => :put do %>
-        <%= button Spree.t('regenerate_key', :scope => 'api'), 'refresh' %>
-      <% end %>
+      <% end %>      
     </div>
 
   <% else %>


### PR DESCRIPTION
@quetzaluz 
This simply removes the `regenerate_api_key` button from the UI to handle https://github.com/dotandbo/dotandbo-spree/issues/4764
