### PR TITLE
- Removes touch actions which are now redundant for us given changes in dotandbo/dotandbo-spree

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -12,9 +12,6 @@ module Spree
 
     delegate :weight, :should_track_inventory?, to: :variant
 
-    after_save :conditional_variant_touch, if: :changed?
-    after_touch { variant.touch }
-
     self.whitelisted_ransackable_attributes = ['count_on_hand', 'stock_location_id']
 
     def backordered_inventory_units


### PR DESCRIPTION
@kknd113 -- this isn't the most urgent, but it might help performance.

I noticed while working on https://github.com/dotandbo/dotandbo-spree/issues/4797 that we have duplicate touch actions between dotandbo/spree and dotandbo/dotandbo-spree.

I decided to remove the duplicates in dotandbo/spree because @timkutnick 's change here (https://github.com/dotandbo/dotandbo-spree/pull/4857/files) modifies the touch action to also update the product, which given how we cache views by products is a good course of action.
