### PR TITLE
- Removes StockItem#count_on_hand >= 0 validation to prevent critical errors when updating order.

### DIFF
--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -58,6 +58,9 @@ module Spree
     end
 
     private
+      def verify_count_on_hand?
+        count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)
+      end
 
       def count_on_hand=(value)
         write_attribute(:count_on_hand, value)

--- a/core/app/models/spree/stock_item.rb
+++ b/core/app/models/spree/stock_item.rb
@@ -8,7 +8,6 @@ module Spree
 
     validates_presence_of :stock_location, :variant
     validates_uniqueness_of :variant_id, scope: [:stock_location_id, :deleted_at]
-    validates :count_on_hand, numericality: { greater_than_or_equal_to: 0 }, if: :verify_count_on_hand?
 
     delegate :weight, :should_track_inventory?, to: :variant
 
@@ -59,9 +58,6 @@ module Spree
     end
 
     private
-      def verify_count_on_hand?
-        count_on_hand_changed? && !backorderable? && (count_on_hand < count_on_hand_was) && (count_on_hand < 0)
-      end
 
       def count_on_hand=(value)
         write_attribute(:count_on_hand, value)


### PR DESCRIPTION
@kknd113 

Change approved here: https://github.com/dotandbo/dotandbo-spree/issues/4797#issuecomment-157552333

Specs ran and pased here: https://codeship.com/projects/23106/builds/9919822?pipeline=54cdfc04-4920-464b-a3e2-4e47bbd748e9
