### PR TITLE
- Prevents compute_nil_class from being called by preemptively checking if argument passed will be nil

### DIFF
--- a/core/app/models/spree/adjustment.rb
+++ b/core/app/models/spree/adjustment.rb
@@ -86,7 +86,7 @@ module Spree
     # Chances are likely that this was a manually created adjustment in the admin backend.
     def update!(target = nil)
       return amount if closed?
-      if source.present?
+      if source.present? && (target || adjustable).present?
         amount = source.compute_amount(target || adjustable)
         self.update_columns(
           amount: amount,


### PR DESCRIPTION
@kknd113 -- I am happy to move this to dotandbo-spree repo if preferred. Moving this will require a class decorator for Spree::Adjustment since we haven't had to set one of those up yet, whereas this is just a one line change.

The bug is caused by compute_nil_class being called. That method is currently defined as such:

```
    def compute_nil_class(nil_class)
      logger.error "compute_nil_class should never be called: calculator id: self.try(:id)"
    end
```

Which returns true, causing the `true cannot be coerced into Float` error we're seeing (see terminal output at the end of this description for evidence of this.

Because the logged message says explicitly that `compute_nil_class should never be called`, I went with this approach of not calling any compute methods if `target` and `adjustable` are nil.

Again, happy to get this change out of our public repo here and do apply this approach in a `Spree::Adjustment.class_eval` decorator in dotandbo-spree if preferred.
