### PR TITLE
- Modifies cache key for variants/show rabl

### DIFF
--- a/api/app/views/spree/api/variants/show.v1.rabl
+++ b/api/app/views/spree/api/variants/show.v1.rabl
@@ -1,5 +1,5 @@
 object @variant
-cache @variant
+cache [@variant, @guaranteed_by_campaign]
 extends "spree/api/variants/variant"
 child(:option_values => :option_values) { attributes *option_value_attributes }
 child(:images => :images) { extends "spree/api/images/show" }


### PR DESCRIPTION
@kknd113 -- It makes more sense to put this change in our dotandbo-spree repo. However, we currently don't have a template override there so I thought I'd put this fix up here first so that you can see this as a one line change.

I've tested this in the case where there is a guaranteed_by_campaign present and in the case where it's not present. When it's not present the addition here evaluates to nil without breaking the caching functionality.

Here's the spec run with this feature: https://codeship.com/projects/23106/builds/10554241

I am also looking into setting up a staging instance with cache settings that resemble production for additional testing.
